### PR TITLE
Update to Muzei API 3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.fabric'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     applicationId "com.michaldrabik.muzeipixelartextension"
     minSdkVersion 19
@@ -67,7 +67,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-moshi:2.6.2'
   implementation 'com.squareup.okhttp3:logging-interceptor:4.2.2'
 
-  implementation 'com.google.android.apps.muzei:muzei-api:3.2.0'
+  implementation 'com.google.android.apps.muzei:muzei-api:3.4.0'
   implementation('com.crashlytics.sdk.android:crashlytics:2.9.8@aar') {
     transitive = true
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,18 @@
 				/>
 		</provider>
 
+		<provider
+			android:name="com.google.android.apps.muzei.api.provider.MuzeiArtDocumentsProvider"
+			android:authorities="${pixelArtAuthority}.documents"
+			android:exported="true"
+			android:grantUriPermissions="true"
+			android:permission="android.permission.MANAGE_DOCUMENTS"
+			>
+			<intent-filter>
+				<action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+			</intent-filter>
+		</provider>
+
 		<meta-data
 			android:name="io.fabric.ApiKey"
 			android:value="${fabricApiKey}"

--- a/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtProvider.kt
+++ b/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtProvider.kt
@@ -1,9 +1,11 @@
 package com.michaldrabik.muzeipixelartextension
 
+import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
+import androidx.core.app.RemoteActionCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.work.WorkManager
-import com.google.android.apps.muzei.api.UserCommand
 import com.google.android.apps.muzei.api.provider.Artwork
 import com.google.android.apps.muzei.api.provider.MuzeiArtProvider
 
@@ -19,17 +21,18 @@ class PixelArtProvider : MuzeiArtProvider() {
     workManager.enqueue(PixelArtWorker.createRequest())
   }
 
-  /**
-   * Not working in Android 10 as of now:
-   * https://github.com/romannurik/muzei/issues/644
-   **/
+  /* kept for backward compatibility with Muzei 3.3 */
+  @Suppress("OverridingDeprecatedMember", "DEPRECATION")
   override fun getCommands(artwork: Artwork) = when {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> emptyList()
     else -> listOf(
-      UserCommand(COMMAND_DOWNLOAD_ID, context?.getString(R.string.text_download))
+      com.google.android.apps.muzei.api.UserCommand(COMMAND_DOWNLOAD_ID,
+        context?.getString(R.string.text_download))
     )
   }
 
+  /* kept for backward compatibility with Muzei 3.3 */
+  @Suppress("OverridingDeprecatedMember")
   override fun onCommand(artwork: Artwork, id: Int) {
     when (id) {
       COMMAND_DOWNLOAD_ID -> {
@@ -40,5 +43,19 @@ class PixelArtProvider : MuzeiArtProvider() {
         }
       }
     }
+  }
+
+  /* Used for Muzei 3.4+ */
+  override fun getCommandActions(artwork: Artwork): List<RemoteActionCompat> {
+    val context = context ?: return super.getCommandActions(artwork)
+    val intent = Intent(Intent.ACTION_VIEW, artwork.persistentUri)
+    return listOf(
+      RemoteActionCompat(
+        IconCompat.createWithResource(context, R.drawable.muzei_launch_command),
+        context.getString(R.string.text_download),
+        context.getString(R.string.text_download),
+        PendingIntent.getActivity(context, 0, intent, 0)
+      )
+    )
   }
 }

--- a/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtProvider.kt
+++ b/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtProvider.kt
@@ -55,7 +55,9 @@ class PixelArtProvider : MuzeiArtProvider() {
         context.getString(R.string.text_download),
         context.getString(R.string.text_download),
         PendingIntent.getActivity(context, 0, intent, 0)
-      )
+      ).apply {
+        setShouldShowIcon(false)
+      }
     )
   }
 }

--- a/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtWorker.kt
+++ b/app/src/main/java/com/michaldrabik/muzeipixelartextension/PixelArtWorker.kt
@@ -51,13 +51,13 @@ class PixelArtWorker(
     )
     val attributionString = applicationContext.getString(R.string.attribution)
     providerClient.addArtwork(images.map { image ->
-      Artwork().apply {
-        token = image.id
-        title = attributionString
-        attribution = attributionString
-        persistentUri = Uri.parse(image.url)
+      Artwork(
+        token = image.id,
+        title = attributionString,
+        attribution = attributionString,
+        persistentUri = Uri.parse(image.url),
         webUri = Uri.EMPTY
-      }
+      )
     })
 
     Result.success()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
-  ext.kotlin_version = '1.3.20'
+  ext.kotlin_version = '1.3.72'
   repositories {
     google()
     jcenter()
     maven { url 'https://maven.fabric.io/public' }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.0'
+    classpath 'com.android.tools.build:gradle:4.0.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'io.fabric.tools:gradle:1.27.0'
+    classpath 'io.fabric.tools:gradle:1.28.0'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.enableR8=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 25 17:32:53 ICT 2019
+#Thu Jul 23 20:32:24 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Use the new `getCommandActions()` API to fix the 'Download Wallpaper' action on Android 10+ devices. By keeping the old APIs as well, we maintain backward compatibility with Muzei 3.3 users (although they'll still need to upgrade to Muzei 3.4 to get a working acction).

The `PixelArtWorker` was changed to be compatible with the Kotlin rewrite of the Muzei API.

The `MuzeiArtDocumentsProvider` was added to the manifest to allow users to select artwork from the Source via the default file picker / Files app.

Muzei API 3.4 requires Kotlin 1.3.72 and a `compileSdkVersion` of 30 (which then required we upgrade the Android Gradle Plugin to 4.0.1), so those were also updated along with what other requirements went along with that.